### PR TITLE
Return iOS tag reads as bytes

### DIFF
--- a/ios/Sources/NFCPlugin/NFCPlugin.swift
+++ b/ios/Sources/NFCPlugin/NFCPlugin.swift
@@ -22,10 +22,19 @@ public class NFCPlugin: CAPPlugin, CAPBridgedPlugin {
                 var records = [[String: Any]]()
                 for record in message.records {
                     let recordType = String(data: record.type, encoding: .utf8) ?? ""
-                    let payload = String(data: record.payload, encoding: .utf8) ?? ""
+                    var byteArray: [UInt8] = []
+                    record.payload.withUnsafeBytes { buffer in
+                        if let baseAddress = buffer.baseAddress {
+                            for i in 0..<record.payload.count {
+                                let byte = baseAddress.advanced(by: i).load(as: UInt8.self)
+                                byteArray.append(byte)
+                            }
+                        }
+                    }
+                    
                     records.append([
                         "type": recordType,
-                        "payload": payload
+                        "payload": byteArray
                     ])
                 }
                 ndefMessages.append([

--- a/ios/Sources/NFCPlugin/NFCReader.swift
+++ b/ios/Sources/NFCPlugin/NFCReader.swift
@@ -80,6 +80,7 @@ import CoreNFC
                     }
                     
                     if let message = message {
+                        print("NDEF message read: \(message)")
                         statusMessage = "Found 1 NDEF message."
                         session.alertMessage = statusMessage
                         session.invalidate()

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -23,6 +23,16 @@ export interface NFCPlugin {
   ): Promise<PluginListenerHandle> & PluginListenerHandle;
 
   /**
+   * Adds a listener for NFC tag write events.
+   * @param eventName The name of the event ('nfcWriteSuccess').
+   * @param listenerFunc The function to call when an NFC tag is written.
+   */
+  addListener(
+    eventName: 'nfcWriteSuccess',
+    listenerFunc: () => void,
+  ): Promise<PluginListenerHandle> & PluginListenerHandle;
+
+  /**
    * Adds a listener for NFC error events.
    * @param eventName The name of the event ('nfcError').
    * @param listenerFunc The function to call when an NFC error occurs.


### PR DESCRIPTION
* iOS tag records previously returned a Uint8 string, which wipes data for some byte-encoded tags. This version returns a Uint8 byte array.
* Updated definitions.ts to include missing `nfcWriteSuccess` listener definition