### PR TITLE
Add getStatus method to NFCPlugin

### DIFF
--- a/android/src/main/kotlin/com/exxili/capacitornfc/NFCPlugin.kt
+++ b/android/src/main/kotlin/com/exxili/capacitornfc/NFCPlugin.kt
@@ -107,6 +107,19 @@ class NFCPlugin : Plugin() {
         call.resolve()
     }
 
+    @PluginMethod
+    fun getStatus(call: PluginCall) {
+        val adapter = NfcAdapter.getDefaultAdapter(this.activity)
+        val ret = JSObject()
+        val status = when {
+            adapter == null -> "NOT_SUPPORTED"
+            adapter.isEnabled -> "ENABLED"
+            else -> "DISABLED"
+        }
+        ret.put("status", status)
+        call.resolve(ret)
+    }
+
     override fun handleOnPause() {
         super.handleOnPause()
         getDefaultAdapter(this.activity)?.disableForegroundDispatch(this.activity)
@@ -406,18 +419,18 @@ class NFCPlugin : Plugin() {
 
     private fun extractTagInfo(tag: Tag): JSObject {
         val tagInfo = JSObject()
-        
+
         // Always include UID
         val uid = byteArrayToHexString(tag.id)
         tagInfo.put("uid", uid)
-        
+
         // Include technology types
         val techTypes = JSArray()
         for (tech in tag.techList) {
             techTypes.put(tech)
         }
         tagInfo.put("techTypes", techTypes)
-        
+
         // Try to get NDEF-specific information
         val ndef = Ndef.get(tag)
         if (ndef != null) {
@@ -432,7 +445,7 @@ class NFCPlugin : Plugin() {
                 try { ndef.close() } catch (_: Exception) {}
             }
         }
-        
+
         return tagInfo
     }
 

--- a/ios/Sources/NFCPlugin/NFCPlugin.swift
+++ b/ios/Sources/NFCPlugin/NFCPlugin.swift
@@ -11,7 +11,8 @@ public class NFCPlugin: CAPPlugin, CAPBridgedPlugin {
         CAPPluginMethod(name: "cancelWriteAndroid", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "startScan", returnType: CAPPluginReturnPromise),
     CAPPluginMethod(name: "cancelScan", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "writeNDEF", returnType: CAPPluginReturnPromise)
+        CAPPluginMethod(name: "writeNDEF", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getStatus", returnType: CAPPluginReturnPromise)
     ]
 
     private let reader = NFCReader()

--- a/ios/Sources/NFCPlugin/NFCPlugin.swift
+++ b/ios/Sources/NFCPlugin/NFCPlugin.swift
@@ -17,8 +17,12 @@ public class NFCPlugin: CAPPlugin, CAPBridgedPlugin {
     private let reader = NFCReader()
     private let writer = NFCWriter()
 
+    private func isNfcAvailable() -> Bool {
+        NFCNDEFReaderSession.readingAvailable
+    }
+
     @objc func isSupported(_ call: CAPPluginCall) {
-        call.resolve(["supported": NFCNDEFReaderSession.readingAvailable])
+        call.resolve(["supported": isNfcAvailable()])
     }
 
     @objc func cancelWriteAndroid(_ call: CAPPluginCall) {
@@ -165,5 +169,12 @@ public class NFCPlugin: CAPPlugin, CAPBridgedPlugin {
 
         writer.startWriting(message: ndefMessage)
         call.resolve()
+    }
+
+    @objc func getStatus(_ call: CAPPluginCall) {
+        let status = isNfcAvailable() ? "ENABLED" : "NOT_SUPPORTED"
+        call.resolve([
+            "status": status
+        ])
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -3,6 +3,14 @@ import type { PluginListenerHandle } from '@capacitor/core';
 // Payload from a new NFC scan is a base64 encoded string
 export type PayloadType = string | number[] | Uint8Array;
 
+/**
+ * NFC status values.
+ * - "ENABLED" means NFC is available and enabled on the device.
+ * - "DISABLED" means NFC is available but currently disabled (android only).
+ * - "NOT_SUPPORTED" means NFC is not available on this device.
+ */
+export type NfcStatus = 'ENABLED' | 'DISABLED' | 'NOT_SUPPORTED';
+
 export interface StartScanOptions {
   /**
    * Select the native reader strategy.
@@ -83,6 +91,11 @@ export interface NFCPluginBasic {
    * @param eventName The name of the event.
    */
   removeAllListeners(eventName: 'nfcTag' | 'nfcError'): Promise<void>;
+
+  /**
+   * Gets the current NFC status on the device.
+   */
+  getStatus(): Promise<{ status: NfcStatus }>;
 }
 
 export interface NDEFMessages<T extends PayloadType = string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ export const NFC: NFCPlugin = {
 
     await NFCPlug.writeNDEF(ndefMessage);
   },
+  getStatus: NFCPlug.getStatus.bind(NFCPlug),
 };
 
 // ----- Payload transformation helpers -----

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,6 @@
 import { WebPlugin } from '@capacitor/core';
 
-import type { StartScanOptions } from './definitions.js';
+import type { NfcStatus, StartScanOptions } from './definitions.js';
 
 export class NFCWeb extends WebPlugin {
   async isSupported(): Promise<{ supported: boolean }> {
@@ -21,5 +21,9 @@ export class NFCWeb extends WebPlugin {
 
   async writeNDEF(_options?: any): Promise<void> {
     throw new Error('NFC is not supported on web');
+  }
+
+  async getStatus(): Promise<{ status: NfcStatus }> {
+    return { status: 'NOT_SUPPORTED' };
   }
 }


### PR DESCRIPTION
This pull request introduces a new method to check the NFC status. The main focus is to provide a way for apps to determine if NFC is enabled, disabled, or not supported on the device, allowing the UI to properly inform the user whenever he needs to enable nfc or if is not supported.